### PR TITLE
Add ability to have type parameters in cap

### DIFF
--- a/test/TestExamples.hs
+++ b/test/TestExamples.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, TypeFamilies, RankNTypes, UndecidableInstances, TemplateHaskell #-}
+{-# LANGUAGE DataKinds, TypeFamilies, RankNTypes, UndecidableInstances, TemplateHaskell, MultiParamTypeClasses, FlexibleInstances #-}
 
 {-# OPTIONS -ddump-splices #-}
 
@@ -80,6 +80,16 @@ testAddingDb = testCase "adding db" $ do
       dbPut "k" "v"
   -- I KNOW THIS IS NOT A PROPER UNIT TEST :)
   -- Check the output in the console manually for now.
+
+-------- Test capability with type parameters -----
+
+-- We test that generated code compiles
+
+data Abc a b m = Abc
+  { _bla :: b -> a -> m String
+  }
+
+makeCap ''Abc
 
 
 -------- Test tree and Main ----------

--- a/test/TestExamples.hs
+++ b/test/TestExamples.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DataKinds, TypeFamilies, RankNTypes, UndecidableInstances, TemplateHaskell, MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE DataKinds, TypeFamilies, RankNTypes, UndecidableInstances, TemplateHaskell, FlexibleInstances #-}
+-- Needed only for FooBar example
+{-# LANGUAGE MultiParamTypeClasses, ScopedTypeVariables, AllowAmbiguousTypes #-}
 
 {-# OPTIONS -ddump-splices #-}
 
@@ -85,11 +87,12 @@ testAddingDb = testCase "adding db" $ do
 
 -- We test that generated code compiles
 
-data Abc a b m = Abc
-  { _bla :: b -> a -> m String
+data Foobar a b m = Foobar
+  { _bar :: b -> a -> m String
+  , _foo :: m Int
   }
 
-makeCap ''Abc
+makeCap ''Foobar
 
 
 -------- Test tree and Main ----------


### PR DESCRIPTION
Problem: it's impossible to make cap
method dictionary to take type parameters
and methods to actually depend on these type parameters.

Solution: parameterize generated type class
with same type parameters that are used for the data type.